### PR TITLE
Migrate module to Companion v4 and improve websocket reconnect behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+.DS_Store
+*.zip

--- a/COMPANION_V4_MIGRATION.md
+++ b/COMPANION_V4_MIGRATION.md
@@ -1,0 +1,72 @@
+# Companion v4 Migration Notes
+
+## Summary
+
+This module was migrated to Companion v4 runtime format and validated against Companion 4.2.x.
+
+## Runtime Migration
+
+### Added
+
+- `main.js` (Companion v4 runtime entrypoint)
+- `companion/manifest.json` (module manifest)
+- `companion/HELP.md` (module help shown in Companion)
+
+### Updated
+
+- `package.json`
+  - `name` set to `companion-module-nobe-omniscope`
+  - `main` set to `main.js`
+  - dependencies added:
+    - `@companion-module/base`
+    - `ws`
+
+## Behavioral Improvements
+
+The v4 runtime includes websocket resilience improvements:
+
+- automatic reconnect on close/error
+- exponential reconnect backoff
+- socket cleanup during config changes/destroy
+- guarded send behavior when socket is disconnected
+
+## Companion Manifest Requirements
+
+The manifest uses Companion v4 plugin runtime metadata:
+
+- `runtime.type = node18`
+- `runtime.api = nodejs-ipc`
+- `runtime.apiVersion = 1.13.0`
+- `runtime.entrypoint = ../main.js`
+
+These fields are required for Companion to load the module correctly as a dev module.
+
+## Local Dev Module Setup
+
+1. Run `npm install` in this repository.
+2. Set Companion `dev_modules_path` to a directory containing this module folder.
+3. Restart Companion.
+4. Add/enable `Nobe: Omniscope (Dev)`.
+
+## Troubleshooting
+
+### `No config data loaded`
+
+Most common causes:
+
+1. Dependencies not installed (`npm install` missing)
+2. Companion not restarted after dependency install
+3. Wrong dev module path (must point to parent directory containing the module)
+
+### `Cannot find module '@companion-module/base/package.json'`
+
+Run `npm install` in the module directory and restart Companion.
+
+## Test Matrix
+
+Validate at minimum:
+
+1. Companion starts before OmniScope.
+2. OmniScope starts later and module auto-connects.
+3. OmniScope restarts/crashes and module auto-reconnects.
+4. Channel action sends correctly after reconnect.

--- a/HELP.md
+++ b/HELP.md
@@ -1,6 +1,18 @@
-Node Omniscope Control
-Module for use with Nobe Omniscope, software video scopes. Actions are defined in the software, this triggers actions 1-32.
+## Nobe Omniscope Control
 
-Available commands
+Trigger OmniScope channels from Companion over websocket.
 
-Trigger Channel (1-32)
+### Configuration
+
+- `Target IP`: host running OmniScope
+- `Target Port`: websocket port (`4475` by default)
+
+### Action
+
+- `Trigger Channel (1-32)`
+
+### Notes
+
+- The module sends payloads in the OmniScope format:
+  - `{"event":"testEvent","action":<0-31>}`
+- Connection automatically retries after OmniScope restarts or temporary disconnects.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # companion-module-nobe-omniscope
-See [HELP.md](./HELP.md) and [LICENSE](./LICENSE)
+
+Bitfocus Companion module for triggering Nobe OmniScope channels over websocket.
+
+## Status
+
+This repository now includes a Companion v4 module runtime implementation:
+
+- entrypoint: `main.js`
+- manifest: `companion/manifest.json`
+- runtime base: `@companion-module/base`
+
+The legacy `index.js` implementation is kept in the repository for reference, but Companion v4 uses the manifest + `main.js` path.
+
+## Features
+
+- Trigger OmniScope channels `1-32`
+- Configurable target host and port (default `4475`)
+- Automatic websocket reconnect with exponential backoff
+- Safe socket lifecycle handling during reconnects and config updates
+
+## Configuration
+
+- `Target IP`: IP address of the system running OmniScope websocket server
+- `Target Port`: websocket port (`4475` by default)
+
+## Action
+
+- `Trigger Channel`: sends channel trigger payload to OmniScope
+
+Payload format:
+
+```json
+{ "event": "testEvent", "action": 0 }
+```
+
+`action` uses zero-based channel numbering (`0-31`) matching OmniScope websocket behavior.
+
+## Development (Companion v4 dev modules)
+
+1. Install module dependencies:
+
+```sh
+npm install
+```
+
+2. Point Companion `dev_modules_path` to a parent directory containing this module folder.
+3. Restart Companion and add the `Nobe: Omniscope (Dev)` connection.
+
+If Companion shows `No config data loaded` for this module, check dependencies are installed and restart Companion.
+
+## Validation Checklist
+
+1. Start Companion while OmniScope is not running.
+2. Verify module stays in reconnecting/warning state.
+3. Start OmniScope and verify module transitions to connected automatically.
+4. Restart OmniScope and verify module reconnects without manual disable/enable cycle.
+
+## License
+
+See [LICENSE](./LICENSE).

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -1,0 +1,22 @@
+## Nobe Omniscope Control
+
+Triggers channels in Nobe Omniscope over websocket.
+
+### Configuration
+
+- `Target IP`: IP address of the machine running Nobe Omniscope.
+- `Target Port`: websocket port (default `4475`).
+
+### Action
+
+- `Trigger Channel`: Sends channel triggers `1-32` to Nobe Omniscope.
+
+### Connection behavior
+
+- Automatic reconnect is enabled.
+- If OmniScope starts after Companion, the module retries until it connects.
+- If OmniScope restarts or crashes, the module reconnects automatically.
+
+### Troubleshooting
+
+- If the connection editor shows `No config data loaded`, install dependencies with `npm install` in the module directory and restart Companion.

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "nobe-omniscope",
 	"shortname": "NobeScope",
 	"description": "Nobe Omniscope Trigger for Companion",
-	"version": "1.0.3",
+	"version": "2.0.0",
 	"license": "MIT",
 	"repository": "https://github.com/bitfocus/companion-module-nobe-omniscope",
 	"bugs": "https://github.com/bitfocus/companion-module-nobe-omniscope/issues",

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -1,0 +1,30 @@
+{
+	"id": "nobe-omniscope",
+	"name": "nobe-omniscope",
+	"shortname": "NobeScope",
+	"description": "Nobe Omniscope Trigger for Companion",
+	"version": "1.0.3",
+	"license": "MIT",
+	"repository": "https://github.com/bitfocus/companion-module-nobe-omniscope",
+	"bugs": "https://github.com/bitfocus/companion-module-nobe-omniscope/issues",
+	"maintainers": [
+		{
+			"name": "Time in Pixels",
+			"email": "contact@timeinpixels.com"
+		}
+	],
+	"legacyIds": [],
+	"runtime": {
+		"type": "node18",
+		"api": "nodejs-ipc",
+		"apiVersion": "1.13.0",
+		"entrypoint": "../main.js"
+	},
+	"manufacturer": "Nobe",
+	"products": [
+		"Omniscope"
+	],
+	"keywords": [
+		"Video"
+	]
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,340 @@
+const { InstanceBase, InstanceStatus, Regex, runEntrypoint } = require('@companion-module/base')
+
+const DEFAULT_PORT = 4475
+const RECONNECT_INITIAL_MS = 1000
+const RECONNECT_MAX_MS = 10000
+
+const CHANNELS = Array.from({ length: 32 }, (_, index) => ({
+	id: String(index),
+	label: `Channel ${index + 1}`,
+}))
+
+let ExternalWebSocket = undefined
+
+class NobeOmniscopeInstance extends InstanceBase {
+	constructor(internal) {
+		super(internal)
+
+		this.config = {}
+		this.socket = undefined
+		this.socketHandlers = undefined
+		this.reconnectTimer = undefined
+		this.reconnectDelayMs = RECONNECT_INITIAL_MS
+		this.destroying = false
+	}
+
+	async init(config) {
+		this.config = config || {}
+		this.destroying = false
+		this.reconnectDelayMs = RECONNECT_INITIAL_MS
+
+		this.updateActions()
+		this.updateStatus(InstanceStatus.Unknown)
+		this.connectIfConfigured()
+	}
+
+	async destroy() {
+		this.destroying = true
+		this.stopReconnectTimer()
+		this.destroySocket()
+	}
+
+	async configUpdated(config) {
+		this.config = config || {}
+
+		this.reconnectDelayMs = RECONNECT_INITIAL_MS
+		this.stopReconnectTimer()
+		this.destroySocket()
+		this.connectIfConfigured()
+	}
+
+	getConfigFields() {
+		return [
+			{
+				type: 'textinput',
+				id: 'host',
+				label: 'Target IP',
+				width: 8,
+				default: '127.0.0.1',
+				regex: Regex.IP,
+			},
+			{
+				type: 'textinput',
+				id: 'port',
+				label: 'Target Port',
+				width: 4,
+				default: String(DEFAULT_PORT),
+			},
+		]
+	}
+
+	updateActions() {
+		this.setActionDefinitions({
+			triggerChannel: {
+				name: 'Trigger Channel',
+				options: [
+					{
+						type: 'dropdown',
+						label: 'Send Channel Trigger',
+						id: 'channel',
+						default: '0',
+						choices: CHANNELS,
+					},
+				],
+				callback: async (event) => {
+					this.sendChannel(event.options.channel)
+				},
+			},
+		})
+	}
+
+	getHost() {
+		if (!this.config || typeof this.config.host !== 'string') {
+			return ''
+		}
+
+		return this.config.host.trim()
+	}
+
+	getPort() {
+		if (!this.config) {
+			return DEFAULT_PORT
+		}
+
+		const port = parseInt(this.config.port, 10)
+		if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+			return DEFAULT_PORT
+		}
+
+		return port
+	}
+
+	getWebSocketClass() {
+		if (typeof WebSocket !== 'undefined') {
+			return WebSocket
+		}
+
+		if (ExternalWebSocket === undefined) {
+			try {
+				// Optional fallback if runtime does not provide a global WebSocket.
+				ExternalWebSocket = require('ws')
+			} catch (error) {
+				this.log('error', `Nobe: websocket runtime is unavailable: ${error.message}`)
+				ExternalWebSocket = null
+			}
+		}
+
+		return ExternalWebSocket
+	}
+
+	connectIfConfigured() {
+		if (this.getHost() === '') {
+			this.updateStatus(InstanceStatus.Unknown, 'Target IP is required')
+			return
+		}
+
+		this.initSocket()
+	}
+
+	stopReconnectTimer() {
+		if (this.reconnectTimer !== undefined) {
+			clearTimeout(this.reconnectTimer)
+			this.reconnectTimer = undefined
+		}
+	}
+
+	scheduleReconnect() {
+		if (this.destroying || this.getHost() === '') {
+			return
+		}
+
+		if (this.reconnectTimer !== undefined) {
+			return
+		}
+
+		const delay = this.reconnectDelayMs
+		this.updateStatus(InstanceStatus.Connecting, `Reconnecting in ${delay}ms`)
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = undefined
+			this.initSocket()
+		}, delay)
+		this.reconnectDelayMs = Math.min(delay * 2, RECONNECT_MAX_MS)
+	}
+
+	destroySocket() {
+		const socket = this.socket
+
+		if (socket === undefined) {
+			return
+		}
+
+		this.socket = undefined
+
+		if (typeof socket.removeAllListeners === 'function') {
+			socket.removeAllListeners('open')
+			socket.removeAllListeners('close')
+			socket.removeAllListeners('error')
+		} else if (typeof socket.removeEventListener === 'function' && this.socketHandlers) {
+			socket.removeEventListener('open', this.socketHandlers.open)
+			socket.removeEventListener('close', this.socketHandlers.close)
+			socket.removeEventListener('error', this.socketHandlers.error)
+		}
+		this.socketHandlers = undefined
+
+		try {
+			socket.close()
+		} catch (error) {
+			// Ignore close errors while replacing sockets.
+		}
+	}
+
+	initSocket() {
+		const host = this.getHost()
+		const port = this.getPort()
+		const url = `ws://${host}:${port}/`
+		const WebSocketClass = this.getWebSocketClass()
+
+		if (this.destroying || host === '') {
+			return
+		}
+		if (!WebSocketClass) {
+			this.updateStatus(InstanceStatus.ConnectionFailure, 'WebSocket runtime unavailable')
+			return
+		}
+
+		this.stopReconnectTimer()
+		this.destroySocket()
+		this.updateStatus(InstanceStatus.Connecting, `Connecting to ${host}:${port}`)
+
+		let socket
+		try {
+			socket = new WebSocketClass(url)
+		} catch (error) {
+			this.updateStatus(InstanceStatus.ConnectionFailure, 'Connection error')
+			this.log('error', `Nobe: ${host}:${port}: ${this.describeError(error)}`)
+			this.scheduleReconnect()
+			return
+		}
+
+		this.socket = socket
+
+		const handleOpen = () => {
+			if (socket !== this.socket) {
+				return
+			}
+
+			this.reconnectDelayMs = RECONNECT_INITIAL_MS
+			this.updateStatus(InstanceStatus.Ok)
+			this.log('info', `Nobe: connection established to ${host}:${port}`)
+		}
+
+		const handleClose = () => {
+			if (socket !== this.socket) {
+				return
+			}
+
+			this.socket = undefined
+			this.socketHandlers = undefined
+			if (this.destroying) {
+				return
+			}
+
+			this.updateStatus(InstanceStatus.Disconnected, 'Connection closed')
+			this.scheduleReconnect()
+		}
+
+		const handleError = (error) => {
+			if (socket !== this.socket) {
+				return
+			}
+
+			this.updateStatus(InstanceStatus.ConnectionFailure, 'Connection error')
+			this.log('error', `Nobe: ${host}:${port}: ${this.describeError(error)}`)
+			this.scheduleReconnect()
+		}
+
+		if (typeof socket.on === 'function') {
+			socket.on('open', handleOpen)
+			socket.on('close', handleClose)
+			socket.on('error', handleError)
+		} else if (typeof socket.addEventListener === 'function') {
+			const openListener = () => handleOpen()
+			const closeListener = () => handleClose()
+			const errorListener = (event) => handleError(event && (event.error || event.message || event.type))
+
+			socket.addEventListener('open', openListener)
+			socket.addEventListener('close', closeListener)
+			socket.addEventListener('error', errorListener)
+
+			this.socketHandlers = {
+				open: openListener,
+				close: closeListener,
+				error: errorListener,
+			}
+		} else {
+			this.updateStatus(InstanceStatus.ConnectionFailure, 'Unsupported WebSocket implementation')
+			this.log('error', 'Nobe: websocket implementation does not expose on/addEventListener')
+		}
+	}
+
+	describeError(error) {
+		if (!error) {
+			return 'Unknown error'
+		}
+		if (typeof error === 'string') {
+			return error
+		}
+		if (error instanceof Error && error.message) {
+			return error.message
+		}
+		if (typeof error.message === 'string') {
+			return error.message
+		}
+
+		try {
+			return JSON.stringify(error)
+		} catch {
+			return String(error)
+		}
+	}
+
+	isSocketOpen(socket) {
+		if (!socket) {
+			return false
+		}
+
+		const openValue =
+			typeof socket.OPEN === 'number'
+				? socket.OPEN
+				: socket.constructor && typeof socket.constructor.OPEN === 'number'
+					? socket.constructor.OPEN
+					: 1
+
+		return socket.readyState === openValue
+	}
+
+	sendChannel(rawChannel) {
+		const channel = parseInt(rawChannel, 10)
+		if (!Number.isFinite(channel) || channel < 0 || channel > 31) {
+			this.log('error', `Nobe: invalid channel value: ${String(rawChannel)}`)
+			return
+		}
+
+		const cmd = JSON.stringify({ action: channel, event: 'testEvent' })
+		const socket = this.socket
+
+		if (!this.isSocketOpen(socket)) {
+			this.log('warn', 'Nobe: command ignored because socket is not connected')
+			this.scheduleReconnect()
+			return
+		}
+
+		try {
+			socket.send(cmd)
+		} catch (error) {
+			this.log('error', `Nobe: failed to send command: ${this.describeError(error)}`)
+		}
+	}
+}
+
+runEntrypoint(NobeOmniscopeInstance, [])

--- a/package.json
+++ b/package.json
@@ -1,18 +1,16 @@
 {
-	"name": "nobe-omniscope",
-	"version": "1.0.2",
+	"name": "companion-module-nobe-omniscope",
+	"version": "1.0.3",
 	"description": "Nobe Omniscope Trigger for Companion",
-	"main": "index.js",
+	"main": "main.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "node -e \"console.log('No tests configured')\""
 	},
+	"type": "commonjs",
 	"license": "MIT",
 	"keywords": [
 		"Video"
 	],
-	"manufacturer": "Nobe",
-	"product": "Omniscope",
-	"shortname": "NobeScope",
 	"author": "theColourSpace",
 	"homepage": "https://github.com/bitfocus/companion-module-nobe-omniscope#readme",
 	"bugs": {
@@ -22,5 +20,8 @@
 		"type": "git",
 		"url": "git+https://github.com/bitfocus/companion-module-nobe-omniscope.git"
 	},
-	"api_version": "1.0.0"
+	"dependencies": {
+		"@companion-module/base": "^1.13.0",
+		"ws": "^8.18.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "companion-module-nobe-omniscope",
-	"version": "1.0.3",
+	"version": "2.0.0",
 	"description": "Nobe Omniscope Trigger for Companion",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
Summary: migrate the module to Companion v4 runtime format and include websocket reconnect resilience improvements validated in local Companion 4.2.x testing.

Changes:
- add v4 runtime entrypoint (main.js) using @companion-module/base
- add Companion v4 manifest (companion/manifest.json)
- add Companion module help (companion/HELP.md)
- update package metadata and dependencies for v4 runtime
- improve websocket lifecycle and reconnect behavior: auto-reconnect on close/error, exponential backoff, safe cleanup on reconfigure/destroy, guarded sends while disconnected
- expand repository documentation: README.md, HELP.md, COMPANION_V4_MIGRATION.md

Validation:
- module loads in Companion as a dev module
- connection fields load correctly after dependency install
- module connects to OmniScope websocket on 127.0.0.1:4475
- reconnect behavior validated for startup-order and restart scenarios